### PR TITLE
Add selector width to `Mux` primitive

### DIFF
--- a/Haskell/Blarney/Backend/SMT/NetlistUtils.hs
+++ b/Haskell/Blarney/Backend/SMT/NetlistUtils.hs
@@ -195,12 +195,12 @@ showPrim (LessThan _)          ins = bool2bv $ applyOp (text "bvult")  ins
 showPrim (LessThanEq _)        ins = bool2bv $ applyOp (text "bvule")  ins
 showPrim (Equal _)    ins = bool2bv $ applyOp (text "=") ins
 showPrim (NotEqual w) ins = applyOp (text "bvnot") [showPrim (Equal w) ins]
-showPrim (Mux n w) (sel:ins) = mux $ zip [0..] ins
-  where selSz = (ceiling . logBase 2 . fromIntegral) n
-        mux ((_,e):[]) = e
-        mux ((i,e):xs) = applyOp (text "ite")
-                                 [ applyOp (text "=") [sel, int2bv selSz i]
-                                 , e, mux xs ]
+showPrim (Mux n wsel w) (sel:ins) = mux $ zip [0..] ins
+  where
+    mux ((_,e):[]) = e
+    mux ((i,e):xs) = applyOp (text "ite")
+                             [ applyOp (text "=") [sel, int2bv wsel i]
+                             , e, mux xs ]
 -- unsupported primitives
 showPrim p ins = error $
   "Blarney.Backend.SMT.NetlistUtils: cannot showPrim Prim '" ++ show p ++ "'"

--- a/Haskell/Blarney/Backend/Simulation.hs
+++ b/Haskell/Blarney/Backend/Simulation.hs
@@ -356,7 +356,7 @@ compilePrim CompCtxt{..} instId prim ins = case (prim, ins) of
   (SelectBits _ _ _, [x]) -> evalUnOp x
   (Concat _ _, [x, y]) -> evalBinOp x y
   (Identity _, [x]) -> evalUnOp x
-  (Mux _ w, [ss, i0, i1]) ->
+  (Mux _ _ w, [ss, i0, i1]) ->
     [zipWith3 (\s x y -> if s == 0 then x else y) ss i0 i1]
   -- fall through case
   _ -> transpose $ eval <$> transpose ins

--- a/Haskell/Blarney/Core/BV.hs
+++ b/Haskell/Blarney/Core/BV.hs
@@ -275,9 +275,10 @@ concatBV a b = makePrim1 (Concat wa wb) [a, b]
 
 -- |Multiplexer
 muxBV :: BV -> [BV] -> BV
-muxBV sel xs = makePrim1 (Mux n w) (sel:xs)
+muxBV sel xs = makePrim1 (Mux n wsel w) (sel:xs)
                where n = length xs
                      w = bvPrimOutWidth $ head xs
+                     wsel = bvPrimOutWidth sel
 
 -- |Identity function
 idBV :: BV -> BV

--- a/Haskell/Blarney/Core/Prim.hs
+++ b/Haskell/Blarney/Core/Prim.hs
@@ -293,13 +293,13 @@ data Prim =
     --                 @{x, y}@
   | Concat InputWidth InputWidth
 
-    -- | @Mux n w@ represents an @n@-inputs multiplexer
+    -- | @Mux n wsel w@ represents an @n@-input multiplexer
     --
     --   [__inputs__]  @sel:inpts@, with @sel@ a @(log2 n)@-bit value and
     --                 @inpts@ an @n@-sized list of @w@-bit values
     --   [__outputs__] a single output, the @w@-bit value at position @sel@ in
-    --                 @inpts@
-  | Mux Int OutputWidth
+    --                 @inpts@ (the width of @sel@ is @wsel@)
+  | Mux Int InputWidth OutputWidth
 
     -- | @Identity w@ represents an identity function
     --
@@ -753,14 +753,14 @@ primInfo (Concat w0 w1) =
            , isRoot = False
            , inputs = [("in0", w0), ("in1", w1)]
            , outputs = [("out", w0 + w1)] }
-primInfo (Mux n w) =
+primInfo (Mux n wsel w) =
   PrimInfo { isInlineable = False
            , inputsInlineable = True
            , strRep = "Mux"
            , semEval = Just \(s:is) -> [is !! fromIntegral s]
            , dontKill = False
            , isRoot = False
-           , inputs = ("sel", log2ceil n)
+           , inputs = ("sel", wsel)
                       : [("in" ++ show i, w) | i <- [0..n-1]]
            , outputs = [("out", w)] }
 primInfo (Identity w) =

--- a/Haskell/Blarney/Netlist/Passes/ConstantFold.hs
+++ b/Haskell/Blarney/Netlist/Passes/ConstantFold.hs
@@ -88,7 +88,7 @@ evalConstNet n@Net{..} = case n of
   NetP (ArithShiftRight _ w) [Lit 0, _] -> modNet (Const w 0) []
   NetP (ArithShiftRight _ w) [x, Lit 0] -> modNet (Identity w) [x]
   -- Mux
-  NetP (Mux _ w) (Lit s:xs) -> modNet (Identity w) [xs !! fromInteger s]
+  NetP (Mux _ _ w) (Lit s:xs) -> modNet (Identity w) [xs !! fromInteger s]
   -- Registers
   NetP (RegisterEn Nothing w) [_, LitDontCare] -> modNet (DontCare w) []
   NetP (RegisterEn Nothing w) [Lit 0, _] -> modNet (DontCare w) []

--- a/Haskell/Blarney/Netlist/Passes/ZeroWidthNetIgnore.hs
+++ b/Haskell/Blarney/Netlist/Passes/ZeroWidthNetIgnore.hs
@@ -68,6 +68,11 @@ zeroWidthNetTransform net@Net{ netPrim = prim@Custom{ customInputs = primIns
         ins' = [x | x@(_, (_, w)) <- ins, w /= 0]
         (netIns', primIns') = unzip ins'
         primOuts' = [x | x@(_, w) <- primOuts, w /= 0]
+-- Remove 0-width registers to break 0-width cycles
+zeroWidthNetTransform net@Net{ netPrim = Register _ 0 } =
+  (net { netPrim = Const 0 0, netInputs = [] }, True)
+zeroWidthNetTransform net@Net{ netPrim = RegisterEn _ 0 } =
+  (net { netPrim = Const 0 0, netInputs = [] }, True)
 -- TODO currently unsupported cases that could be transformed
 zeroWidthNetTransform net@Net{ netPrim = BRAM { ramAddrWidth = 0 } } =
   error "zeroWidthNetTransform unsupported on BRAM Prim"

--- a/Haskell/Blarney/Netlist/Passes/ZeroWidthNetIgnore.hs
+++ b/Haskell/Blarney/Netlist/Passes/ZeroWidthNetIgnore.hs
@@ -41,6 +41,8 @@ zeroWidthNetTransform net@Net{ netPrim = SignExtend 0 w } =
   (net { netPrim = Const w 0, netInputs = [] }, True)
 zeroWidthNetTransform net@Net{ netPrim = SelectBits 0 hi lo } =
   (net { netPrim = Const (hi-lo) 0, netInputs = [] }, True)
+zeroWidthNetTransform net@Net{ netPrim = Mux n 0 w } =
+  (net { netPrim = Identity w, netInputs = [netInputs net !! 1] }, True)
 zeroWidthNetTransform net@Net{ netPrim = Concat w0 w1, netInputs = [i0, i1] }
   | w0 == 0 && w1 /= 0 = (net { netPrim = Identity w1, netInputs = [i1] }, True)
   | w0 /= 0 && w1 == 0 = (net { netPrim = Identity w0, netInputs = [i0] }, True)


### PR DESCRIPTION
I noticed that `Bit 0` elimination was not working for a mux with a
0-bit selector.  To fix this, I added the selector width as an
argument to the Mux prim.  Previously the width was being inferred
from the number of inputs, but this was not consistent with (enforced
against) the actual width of the input selector signal.