### PR TITLE
The chaining function used for verification was incorrect

### DIFF
--- a/Haskell/Blarney/Backend/SMT/BasicDefinitions.hs
+++ b/Haskell/Blarney/Backend/SMT/BasicDefinitions.hs
@@ -163,7 +163,7 @@ defineChain name (f, (a0Sort, a1Sort), retSort) =
                                  [( text "(mkTuple2 rets ys)", recRet)]
         recRet = applyOp (text "mkTuple2")
                          [ applyOp (text "cons") [text "ret", text "rets"]
-                         , applyOp (text "cons") [text "next", text "ys"] ]
+                         , applyOp (text "cons") [text "prev", text "ys"] ]
         retLst = "(ListX " ++ retSort ++ ")"
         a0Lst = "(ListX " ++ a0Sort ++ ")"
         a1Lst = "(ListX " ++ a1Sort ++ ")"


### PR DESCRIPTION
The chaining function used for verification was incorrect.
It returned `(_, [state.1, state.2, ..., state.(k+1), state.(k+1)])` instead of the expectable `(_, [state.0, state.1, ..., state.k, state.(k+1)])`.
This in turn made the restricted state condition incorrect, off by one.

This fixes #130 